### PR TITLE
Pipeline script

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,10 +4,14 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - clangxx_osx-64
+  - cxx-compiler
+  - blas-devel
   - mkl-service
-  - libcxx
   - numpy
+  - theano
+  - tensorflow
+  - blas
+  - pymc3>=3.8,<3.10
   - pandas<1.3
   - h5py<3.2
   - jupyter
@@ -20,7 +24,6 @@ dependencies:
   - click
   - pip
   - pip:
-    - pymc3>=3.8,<3.10
     - diffxpy
     - torch
     - arviz==0.11.1

--- a/pipeline/cc.py
+++ b/pipeline/cc.py
@@ -1,0 +1,104 @@
+import sys,os
+import click
+import pickle
+import anndata
+import pandas as pd
+import numpy as np
+import scanpy as sc
+import matplotlib.pyplot as plt
+import seaborn as sns
+import diffxpy.api as de
+from IPython.display import Image
+data_type = 'float32'
+os.environ["THEANO_FLAGS"] = 'device=cpu,floatX=' + data_type + ',force_device=True' + ',dnn.enabled=False'
+import countcorrect as cc
+from countcorrect.ProbeCounts__GeneralModel import ProbeCounts_GeneralModel
+
+
+@click.command()
+@click.option(
+ '--genes',
+ help = 'Full path to CSV file containing count matrix for gene probes',
+ type = click.Path(exists = True),
+ required = True
+)
+@click.option(
+ '--negs',
+ help = 'Full path to CSV file containing count matrix for negative control probes',
+ type = click.Path(exists = True),
+ required = True
+)
+@click.option(
+ '--nuclei',
+ help = 'Full path to file containing the number of nuclei per ROI, one per line, in the same order as the other files',
+ type = click.Path(exists = True),
+ required = True
+)
+@click.option(
+ '--n_iter',
+ help = 'Number of iterations for fitting the model',
+ type = click.INT,
+ required = True
+)
+def remove_background(genes, negs, nuclei, n_iter):
+  click.echo('Gene probes path: ' + genes)
+  click.echo('Negative probe path: ' + negs)
+  click.echo('Nuclei counts: ' + nuclei)
+  click.echo('Number of iterations: ' + str(n_iter))
+  click.echo("Loading data...")
+  geneProbes = np.genfromtxt(
+    genes,
+    delimiter = ',',
+    dtype = 'float32'
+    )
+  click.echo("Loaded gene probes: " + str(geneProbes.shape))
+  negProbes = np.genfromtxt(
+    negs,
+    delimiter = ',',
+    dtype = 'float32'
+    )
+  click.echo("Loaded negative probes: " + str(negProbes.shape))
+  nuclei = np.genfromtxt(
+    nuclei,
+    delimiter = ',',
+    dtype = 'float32'
+    )
+  click.echo("Loaded nuclei counts: " + str(nuclei.shape))
+  plt.ioff()
+  click.echo("Creating model ...")
+  model = ProbeCounts_GeneralModel(
+    X_data = geneProbes,
+    Y_data = negProbes,
+    nuclei = nuclei,
+    data_type = 'float32',
+    n_factors = 30
+    )
+  click.echo("Fitting model ...")
+  model.fit_advi_iterative(
+    n_iter = n_iter,
+    learning_rate = 0.01,
+    n=1,
+    method='advi'
+    )
+  plt.savefig("Figure0")
+  click.echo("Sampling posterior ...")
+  model.sample_posterior(
+    node='all',
+    n_samples=100,
+    save_samples=True
+    )
+  click.echo("Computing correctons ...")
+  model.compute_X_corrected()
+  click.echo("Saving to CSV ...")
+  np.savetxt(
+    "corrected_counts.csv",
+    model.X_corrected_mean,
+    delimiter=","
+    )
+  click.echo("Plotting ...")
+  model.plot_X_corrected_overview2()
+  plt.savefig("Figure1")
+  model.plot_X_corrected_overview3(saveFig = "Figure2.png")
+  model.plot_X_corrected_overview5(['g_1','g_2'], saveFig = "Figure3.png")
+  click.echo("Ranking ...")
+  model.rank_X_corrected_genes().to_csv('ranked_correctons.csv')

--- a/pipeline/setup.py
+++ b/pipeline/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup
+
+setup(
+    name='cc',
+    version='0.1.0',
+    py_modules=['cc'],
+    install_requires=[
+        'Click',
+    ],
+    entry_points={
+        'console_scripts': [
+            'cc = cc:remove_background',
+        ],
+    },
+)


### PR DESCRIPTION
Hi. This pull request is intended to illustrate how we have been trying to use CountCorrect functions in our pipelines. Feel free to merge if you think this is worthwhile but mainly I would like to run this by you.
There are some minor changes to `environment.yml` but the main additions are in a folder called `pipeline`. If you choose to merge feel free to reorganise as you see fit. 
`cc.py` uses the `click` passage to take arguments from the command line, namely `--genes`, `--negs`, `--nuclei` and `--n_iter`. These arguments are used to initialise and fit a model, and then return some plots and CSV files along with the corrected count matrix. I am sure that this can be improved/extended.
In order to test cc.py, activate the conda environment and then run `pip install --editable pipeline/`

The script appears to work correctly for the demo data provided. However, when I run it on a large Nanostring dataset with 686 AOIs I run out of memory while sampling the posterior, despite requesting 192 GB RAM. I will continue to experiment with extra memory but I would like to inquire about one detail.

Does the model fit the distribution of negative probes independently for each AOI? Or are the negative probe counts for all AOIs considered collectively when fitting in the model?
That is, can I split the data set into smaller groups of samples in order to use less compute resources?  Or will that invalidate the assumptions of the algorithm?